### PR TITLE
Raise ImportError if using CircuitPython < 3.

### DIFF
--- a/adafruit_hid/consumer_control.py
+++ b/adafruit_hid/consumer_control.py
@@ -32,6 +32,7 @@ import sys
 if sys.implementation[1][0] < 3:
     raise ImportError('{0} is not supported in CircuitPython 2.x or lower'.format(__name__))
 
+# pylint: disable=wrong-import-position
 import time
 import usb_hid
 

--- a/adafruit_hid/consumer_control.py
+++ b/adafruit_hid/consumer_control.py
@@ -28,6 +28,10 @@
 * Author(s): Dan Halbert
 """
 
+import sys
+if sys.implementation[1][0] < 3:
+    raise ImportError('{0} is not supported in CircuitPython 2.x or lower'.format(__name__))
+
 import time
 import usb_hid
 

--- a/adafruit_hid/gamepad.py
+++ b/adafruit_hid/gamepad.py
@@ -28,6 +28,10 @@
 * Author(s): Dan Halbert
 """
 
+import sys
+if sys.implementation[1][0] < 3:
+    raise ImportError('{0} is not supported in CircuitPython 2.x or lower'.format(__name__))
+
 import struct
 import time
 import usb_hid

--- a/adafruit_hid/gamepad.py
+++ b/adafruit_hid/gamepad.py
@@ -32,6 +32,7 @@ import sys
 if sys.implementation[1][0] < 3:
     raise ImportError('{0} is not supported in CircuitPython 2.x or lower'.format(__name__))
 
+# pylint: disable=wrong-import-position
 import struct
 import time
 import usb_hid


### PR DESCRIPTION
Use sys.implementation to check if using CircuitPython 2 or lower and raise an import error if the version is incompatible.

Fixes: https://github.com/adafruit/Adafruit_CircuitPython_HID/issues/20