### PR TITLE
add ConsumerControlCode.MUTE

### DIFF
--- a/adafruit_hid/consumer_control_code.py
+++ b/adafruit_hid/consumer_control_code.py
@@ -54,6 +54,8 @@ class ConsumerControlCode:
     """Eject"""
     PLAY_PAUSE = 0xCD
     """Play/Pause toggle"""
+    MUTE = 0xE2
+    """Mute"""
     VOLUME_DECREMENT = 0xEA
     """Decrease volume"""
     VOLUME_INCREMENT = 0xE9


### PR DESCRIPTION
Tested on Windows 10 and Ubuntu 18.04. Toggles MUTE. JP tested 0xE2 keycode on Mac.