### PR TITLE
gamepad: Use signed bytes for joystick values in struct.pack_into()

### DIFF
--- a/adafruit_hid/gamepad.py
+++ b/adafruit_hid/gamepad.py
@@ -152,7 +152,7 @@ class Gamepad:
         """Send a report with all the existing settings.
         If ``always`` is ``False`` (the default), send only if there have been changes.
         """
-        struct.pack_into('<HBBBB', self._report, 0,
+        struct.pack_into('<Hbbbb', self._report, 0,
                          self._buttons_state,
                          self._joy_x, self._joy_y,
                          self._joy_z, self._joy_r_z)


### PR DESCRIPTION
Fixes #30.

I'm working on enhancements to `struct` that will validate the range of the values, which will make this a necessity.