### PR TITLE
Allow devices to be passed in, instead of always using usb_hid

### DIFF
--- a/adafruit_hid/consumer_control.py
+++ b/adafruit_hid/consumer_control.py
@@ -35,23 +35,27 @@ if sys.implementation.version[0] < 3:
 # pylint: disable=wrong-import-position
 import struct
 import time
-import usb_hid
 
 class ConsumerControl:
     """Send ConsumerControl code reports, used by multimedia keyboards, remote controls, etc.
-
-    *New in CircuitPython 3.0.*
     """
 
-    def __init__(self):
-        """Create a ConsumerControl object that will send Consumer Control Device HID reports."""
-        self.hid_consumer = None
-        for device in usb_hid.devices:
-            if device.usage_page == 0x0C and device.usage == 0x01:
-                self.hid_consumer = device
-                break
-        if not self.hid_consumer:
-            raise IOError("Could not find an HID Consumer device.")
+    def __init__(self, consumer_device=None):
+        """Create a ConsumerControl object that will send Consumer Control Device HID reports.
+        If consumer_device is None (the default), find a usb_hid device to use.
+        But an equivalent device can be supplied instead for other kinds of consumer devices,
+        such as BLE.
+        It only needs to implement ``send_report()``.
+        """
+        self._consumer_device = consumer_device
+        if not self._consumer_device:
+            import usb_hid
+            for device in usb_hid.devices:
+                if device.usage_page == 0x0C and device.usage == 0x01:
+                    self._consumer_device = device
+                    break
+            if not self._consumer_device:
+                raise IOError("Could not find an HID Consumer device.")
 
         # Reuse this bytearray to send consumer reports.
         self._report = bytearray(2)
@@ -81,6 +85,6 @@ class ConsumerControl:
             consumer_control.send(ConsumerControlCode.SCAN_NEXT_TRACK)
         """
         struct.pack_into("<H", self._report, 0, consumer_code)
-        self.hid_consumer.send_report(self._report)
+        self._consumer_device.send_report(self._report)
         self._report[0] = self._report[1] = 0x0
-        self.hid_consumer.send_report(self._report)
+        self._consumer_device.send_report(self._report)

--- a/adafruit_hid/mouse.py
+++ b/adafruit_hid/mouse.py
@@ -28,7 +28,6 @@
 * Author(s): Dan Halbert
 """
 import time
-import usb_hid
 
 class Mouse:
     """Send USB HID mouse reports."""
@@ -40,15 +39,22 @@ class Mouse:
     MIDDLE_BUTTON = 4
     """Middle mouse button."""
 
-    def __init__(self):
-        """Create a Mouse object that will send USB mouse HID reports."""
-        self.hid_mouse = None
-        for device in usb_hid.devices:
-            if device.usage_page == 0x1 and device.usage == 0x02:
-                self.hid_mouse = device
-                break
-        if not self.hid_mouse:
-            raise IOError("Could not find an HID mouse device.")
+    def __init__(self, mouse_device=None):
+        """Create a Mouse object that will send USB mouse HID reports.
+        If mouse_device is None (the default), find a usb_hid device to use.
+        But an equivalent device can be supplied instead for other kinds of nice,
+        such as BLE.
+        It only needs to implement ``send_report()``.
+        """
+        self._mouse_device = mouse_device
+        if not self._mouse_device:
+            import usb_hid
+            for device in usb_hid.devices:
+                if device.usage_page == 0x1 and device.usage == 0x02:
+                    self._mouse_device = device
+                    break
+            if not self._mouse_device:
+                raise IOError("Could not find an HID mouse device.")
 
         # Reuse this bytearray to send mouse reports.
         # report[0] buttons pressed (LEFT, MIDDLE, RIGHT)
@@ -147,7 +153,7 @@ class Mouse:
             self.report[1] = partial_x & 0xff
             self.report[2] = partial_y & 0xff
             self.report[3] = partial_wheel & 0xff
-            self.hid_mouse.send_report(self.report)
+            self._mouse_device.send_report(self.report)
             x -= partial_x
             y -= partial_y
             wheel -= partial_wheel
@@ -157,7 +163,7 @@ class Mouse:
         self.report[1] = 0
         self.report[2] = 0
         self.report[3] = 0
-        self.hid_mouse.send_report(self.report)
+        self._mouse_device.send_report(self.report)
 
     @staticmethod
     def _limit(dist):


### PR DESCRIPTION
This is to be used in conjunction with `HIDServer` from the Adafruit_CircuitPython_BLE library. There is also a bunch of cleanup. I am not sure this is the final API.