### PR TITLE
consumer control code: update link to HID usage tables

### DIFF
--- a/adafruit_hid/consumer_control_code.py
+++ b/adafruit_hid/consumer_control_code.py
@@ -33,7 +33,7 @@ class ConsumerControlCode:
     """USB HID Consumer Control Device constants.
 
     This list includes a few common consumer control codes from
-    http://www.usb.org/developers/hidpage/Hut1_12v2.pdf#page=75.
+    https://www.usb.org/sites/default/files/hut1_21_0.pdf#page=118.
 
     *New in CircuitPython 3.0.*
     """

--- a/adafruit_hid/consumer_control_code.py
+++ b/adafruit_hid/consumer_control_code.py
@@ -15,8 +15,6 @@ class ConsumerControlCode:
 
     This list includes a few common consumer control codes from
     https://www.usb.org/sites/default/files/hut1_21_0.pdf#page=118.
-
-    *New in CircuitPython 3.0.*
     """
 
     # pylint: disable-msg=too-few-public-methods

--- a/adafruit_hid/keycode.py
+++ b/adafruit_hid/keycode.py
@@ -14,7 +14,7 @@ class Keycode:
     """USB HID Keycode constants.
 
     This list is modeled after the names for USB keycodes defined in
-    https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf#page=53.
+    https://usb.org/sites/default/files/hut1_21_0.pdf#page=83.
     This list does not include every single code, but does include all the keys on
     a regular PC or Mac keyboard.
 


### PR DESCRIPTION
The old file was not available anymore. I believe this is where it was pointing at in the document.