### PR TITLE
Add the ability to use the LED indicators for CAPS_LOCK et al.

### DIFF
--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -23,9 +23,13 @@ class Keyboard:
     """Send HID keyboard reports."""
 
     LED_NUM_LOCK = 0x01
+    """LED Usage ID for Num Lock"""
     LED_CAPS_LOCK = 0x02
+    """LED Usage ID for Caps Lock"""
     LED_SCROLL_LOCK = 0x04
+    """LED Usage ID for Scroll Lock"""
     LED_COMPOSE = 0x08
+    """LED Usage ID for Compose"""
 
     # No more than _MAX_KEYPRESSES regular keys may be pressed at once.
 
@@ -155,5 +159,22 @@ class Keyboard:
         return self._keyboard_device.last_received_report
 
     def led_on(self, led_code):
-        """Returns whether an LED is on based on the led code"""
+        """Returns whether an LED is on based on the led code
+
+        Examples::
+
+            import usb_hid
+            from adafruit_hid.keyboard import Keyboard
+            from adafruit_hid.keycode import Keycode
+            import time
+
+            # Press and release CapsLock.
+            kbd.press(Keycode.CAPS_LOCK)
+            time.sleep(.09)
+            kbd.release(Keycode.CAPS_LOCK)
+
+            # Check status of the LED_CAPS_LOCK
+            print(kbd.led_on(Keyboard.LED_CAPS_LOCK))
+
+        """
         return bool(self.led_status[0] & led_code)

--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -22,6 +22,11 @@ _MAX_KEYPRESSES = const(6)
 class Keyboard:
     """Send HID keyboard reports."""
 
+    LED_NUM_LOCK = 0x01
+    LED_CAPS_LOCK = 0x02
+    LED_SCROLL_LOCK = 0x04
+    LED_COMPOSE = 0x08
+
     # No more than _MAX_KEYPRESSES regular keys may be pressed at once.
 
     def __init__(self, devices):
@@ -143,3 +148,12 @@ class Keyboard:
             for i in range(_MAX_KEYPRESSES):
                 if self.report_keys[i] == keycode:
                     self.report_keys[i] = 0
+
+    @property
+    def led_status(self):
+        """Returns the last received report"""
+        return self._keyboard_device.last_received_report
+
+    def led_on(self, led_code):
+        """Returns whether an LED is on based on the led code"""
+        return bool(self.led_status[0] & led_code)


### PR DESCRIPTION
This adds the ability to read the LED status of `CAPS_LOCK`, `NUM_LOCK`, `SCROLL_LOCK`, & `COMPOSE`.

```py
LED_NUM_LOCK  # Works on Windows, RaspberryPi
LED_CAPS_LOCK # Works on Windows, RaspberryPi, Mac
LED_SCROLL_LOCK # Works on Windows
LED_COMPOSE  # Not Tested
```

## Test Code
```py
import usb_hid
from adafruit_hid.keyboard import Keyboard
from adafruit_hid.keycode import Keycode
import time

KEY_DELAY = .09

key_actions = [
    {
        "name": "Caps Lock",
        "keycode": Keycode.CAPS_LOCK,
        "led_code": Keyboard.LED_CAPS_LOCK
    },
    {
        "name": "Caps Lock",
        "keycode": Keycode.SCROLL_LOCK,
        "led_code": Keyboard.LED_SCROLL_LOCK
    },
    {
        "name": "Caps Lock",
        "keycode": Keycode.KEYPAD_NUMLOCK,
        "led_code": Keyboard.LED_NUM_LOCK
    },
]
kbd = Keyboard(usb_hid.devices)

for action in key_actions:
    for i in range(2):
        kbd.press(action['keycode'])
        time.sleep(KEY_DELAY)
        kbd.release(action['keycode'])
        print(f"{action['name']}: {kbd.led_on(action['led_code']}"))
    print()
```

