### PR TITLE
move gamepad.py to examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,8 +124,6 @@ The ``Mouse`` class simulates a three-button mouse with a scroll wheel.
 The ``ConsumerControl`` class emulates consumer control devices such as
 remote controls, or the multimedia keys on certain keyboards.
 
-*New in CircuitPython 3.0.*
-
 .. code-block:: python
 
     import usb_hid
@@ -139,23 +137,6 @@ remote controls, or the multimedia keys on certain keyboards.
 
     # Pause or resume playback.
     cc.send(ConsumerControlCode.PLAY_PAUSE)
-
-The ``Gamepad`` class emulates a two-joystick gamepad with 16 buttons.
-
-*New in CircuitPython 3.0.*
-
-.. code-block:: python
-
-    import usb_hid
-    from adafruit_hid.gamepad import Gamepad
-
-    gp = Gamepad(usb_hid.devices)
-
-    # Click gamepad buttons.
-    gp.click_buttons(1, 7)
-
-    # Move joysticks.
-    gp.move_joysticks(x=2, y=0, z=-20)
 
 Contributing
 ============

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,3 @@
 
 .. automodule:: adafruit_hid.consumer_control_code
    :members:
-
-.. automodule:: adafruit_hid.gamepad
-   :members:

--- a/examples/gamepad.py
+++ b/examples/gamepad.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-`adafruit_hid.gamepad.Gamepad`
+`Gamepad`
 ====================================================
 
 * Author(s): Dan Halbert
@@ -12,7 +12,7 @@
 import struct
 import time
 
-from . import find_device
+from adafruit_hid import find_device
 
 
 class Gamepad:

--- a/examples/hid_joywing_gamepad.py
+++ b/examples/hid_joywing_gamepad.py
@@ -10,7 +10,7 @@ import busio
 from micropython import const
 import adafruit_seesaw
 import usb_hid
-from adafruit_hid.gamepad import Gamepad
+from gamepad import Gamepad
 
 
 def range_map(value, in_min, in_max, out_min, out_max):

--- a/examples/hid_simple_gamepad.py
+++ b/examples/hid_simple_gamepad.py
@@ -6,7 +6,7 @@ import digitalio
 import analogio
 import usb_hid
 
-from adafruit_hid.gamepad import Gamepad
+from gamepad import Gamepad
 
 gp = Gamepad(usb_hid.devices)
 


### PR DESCRIPTION
In CircuitPython 7.0.0, there will no longer be a builtin `Gamepad` HID device. Instead, you will be able to supply your own HID descriptors for whatever kind of gamepad you want.

This removes `gamepad.py` from the library, and move it to `examples/`, with very slight changes. Once dynamic USB descriptors is in a 7.0.0 alpha or beta release, I will update the example to include details of creating an example gamepad `usb_hid.Device`, or else move it to a new library.

I looked in the Learn Guides, and there are none that use the current `Gamepad` functionality.  So I think it's safe to remove the functionality from the current library. It will receive a major version increment. The current `Gamepad` only works on Windows. It may work slightly on MacOS, but it can interfere with the mouse. It does not work on Linux.

Removing `Gamepad` has the additional advantage of saving 2.6kB in frozen library space on those boards that freeze HID. This space will be very helpful in compensating for the additional firmware space needed for the new Circuitpyon 7.0.0 dynamic USB code.