### PR TITLE
fix led_on example

### DIFF
--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -168,6 +168,9 @@ class Keyboard:
             from adafruit_hid.keycode import Keycode
             import time
 
+            # Initialize Keybaord
+            kbd = Keyboard(usb_hid.devices)
+            
             # Press and release CapsLock.
             kbd.press(Keycode.CAPS_LOCK)
             time.sleep(.09)

--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -170,7 +170,7 @@ class Keyboard:
 
             # Initialize Keybaord
             kbd = Keyboard(usb_hid.devices)
-            
+
             # Press and release CapsLock.
             kbd.press(Keycode.CAPS_LOCK)
             time.sleep(.09)


### PR DESCRIPTION
The example for `led_on` didn't initialize the keyboard.