### PR TITLE
adding brightness consumer codes

### DIFF
--- a/adafruit_hid/consumer_control_code.py
+++ b/adafruit_hid/consumer_control_code.py
@@ -41,3 +41,7 @@ class ConsumerControlCode:
     """Decrease volume"""
     VOLUME_INCREMENT = 0xE9
     """Increase volume"""
+    BRIGHTNESS_DECREMENT = 0x70
+    """Decrease Brightness"""
+    BRIGHTNESS_INCREMENT = 0x6F
+    """Increase Brightness"""

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,18 +3,42 @@ Simple test
 
 Ensure your device works with this simple test.
 
+.. literalinclude:: ../examples/hid_simpletest.py
+    :caption: examples/hid_simpletest.py
+    :linenos:
+
+Keyboard Shortcuts
+-------------------
+
+Send ALT+Tab for swapping windows, and CTRL+K for searching in a browser.
+
 .. literalinclude:: ../examples/hid_keyboard_shortcuts.py
     :caption: examples/hid_keyboard_shortcuts.py
     :linenos:
 
-.. literalinclude:: ../examples/hid_simpletest.py
-    :caption: examples/hid_simpletest.py
-    :linenos:
+Simple Gamepad
+---------------
+
+Send gamepad buttons and joystick to the host.
 
 .. literalinclude:: ../examples/hid_simple_gamepad.py
     :caption: examples/hid_simple_gamepad.py
     :linenos:
 
+HID Joywing
+------------
+
+Use Joy FeatherWing to drive Gamepad.
+
 .. literalinclude:: ../examples/hid_joywing_gamepad.py
     :caption: examples/hid_joywing_gamepad.py
+    :linenos:
+
+Consumer Control Brightness
+----------------------------
+
+Send brightness up and down consumer codes to the host.
+
+.. literalinclude:: ../examples/hid_consumer_control_brightness.py
+    :caption: examples/hid_consumer_control_brightness.py
     :linenos:

--- a/examples/hid_consumer_control_brightness.py
+++ b/examples/hid_consumer_control_brightness.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2021 Tim C for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import time
+import board
+import digitalio
+import usb_hid
+from adafruit_hid.consumer_control import ConsumerControl
+from adafruit_hid.consumer_control_code import ConsumerControlCode
+
+cc = ConsumerControl(usb_hid.devices)
+
+# define buttons. these can be any physical switches/buttons, but the values
+# here work out-of-the-box with a FunHouse UP and DOWN buttons.
+button_up = digitalio.DigitalInOut(board.BUTTON_UP)
+button_up.switch_to_input(pull=digitalio.Pull.DOWN)
+
+button_down = digitalio.DigitalInOut(board.BUTTON_DOWN)
+button_down.switch_to_input(pull=digitalio.Pull.DOWN)
+
+while True:
+    if button_up.value:
+        print("Button up pressed!")
+        # send brightness up button press
+        cc.send(ConsumerControlCode.BRIGHTNESS_INCREMENT)
+
+    if button_down.value:
+        print("Button down pressed!")
+        # send brightness down button press
+        cc.send(ConsumerControlCode.BRIGHTNESS_DECREMENT)
+
+    time.sleep(0.1)

--- a/examples/hid_joywing_gamepad.py
+++ b/examples/hid_joywing_gamepad.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 # Use Joy FeatherWing to drive Gamepad.
+# https://www.adafruit.com/product/3632
+# https://learn.adafruit.com/joy-featherwing
 
 import time
 


### PR DESCRIPTION
This adds some constants for brightness up and down consumer codes and an example that shows their usage.

Tested successfully with a FunHouse on Linux PC and Android.

also added some links to Joy Featherwing in the relevant example.
