### PR TITLE
Use future annotations to allow import on desktop computers

### DIFF
--- a/adafruit_hid/__init__.py
+++ b/adafruit_hid/__init__.py
@@ -18,6 +18,8 @@ Implementation Notes
 """
 
 # imports
+from __future__ import annotations
+
 try:
     from typing import Sequence
     import usb_hid


### PR DESCRIPTION
I needed this so that I could use `adafruit_hid.keycode.Keycode` in some programs to help generate keycode lists on my real computer.