### PR TITLE
Remove unneeded typing import

### DIFF
--- a/adafruit_hid/keycode.py
+++ b/adafruit_hid/keycode.py
@@ -9,11 +9,6 @@
 * Author(s): Scott Shawcroft, Dan Halbert
 """
 
-try:
-    import typing  # pylint: disable=unused-import
-except ImportError:
-    pass
-
 
 class Keycode:
     """USB HID Keycode constants.


### PR DESCRIPTION
Looks like this wasn't needed, so just removing it.