### PR TITLE
Act gracefully when more than 6 keys are reported at once

### DIFF
--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -129,20 +129,22 @@ class Keyboard:
             # Set bit for this modifier.
             self.report_modifier[0] |= modifier
         else:
+            report_keys = self.report_keys
             # Don't press twice.
             for i in range(_MAX_KEYPRESSES):
-                if self.report_keys[i] == 0:
+                report_key = report_keys[i]
+                if report_key == 0:
                     # Put keycode in first empty slot. Since the report_keys
                     # are compact and unique, this is not a repeated key
-                    self.report_keys[i] = keycode
+                    report_keys[i] = keycode
                     return
-                if self.report_keys[i] == keycode:
+                if report_key == keycode:
                     # Already pressed.
                     return
             # All slots are filled. Shuffle down and reuse last slot
             for i in range(_MAX_KEYPRESSES - 1):
-                self.report_keys[i] = self.report_keys[i + 1]
-            self.report_keys[-1] = keycode
+                report_keys[i] = report_keys[i + 1]
+            report_keys[-1] = keycode
 
     def _remove_keycode_from_report(self, keycode: int) -> None:
         """Remove a single keycode from the report."""
@@ -151,20 +153,21 @@ class Keyboard:
             # Turn off the bit for this modifier.
             self.report_modifier[0] &= ~modifier
         else:
+            report_keys = self.report_keys
             # Clear the at most one matching slot and move remaining keys down
             j = 0
             for i in range(_MAX_KEYPRESSES):
-                pressed = self.report_keys[i]
+                pressed = report_keys[i]
                 if not pressed:
                     break  # Handled all used report slots
                 if pressed == keycode:
                     continue  # Remove this entry
                 if i != j:
-                    self.report_keys[j] = self.report_keys[i]
+                    report_keys[j] = report_keys[i]
                 j += 1
             # Clear any remaining slots
-            while j < _MAX_KEYPRESSES and self.report_keys[j]:
-                self.report_keys[j] = 0
+            while j < _MAX_KEYPRESSES and report_keys[j]:
+                report_keys[j] = 0
                 j += 1
 
     @property

--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -11,16 +11,12 @@
 
 import time
 from micropython import const
+import usb_hid
 
 from .keycode import Keycode
 
 from . import find_device
 
-try:
-    from typing import Sequence
-    import usb_hid
-except ImportError:
-    pass
 
 _MAX_KEYPRESSES = const(6)
 
@@ -39,7 +35,7 @@ class Keyboard:
 
     # No more than _MAX_KEYPRESSES regular keys may be pressed at once.
 
-    def __init__(self, devices: Sequence[usb_hid.Device]) -> None:
+    def __init__(self, devices: list[usb_hid.Device]) -> None:
         """Create a Keyboard object that will send keyboard HID reports.
 
         Devices can be a sequence of devices that includes a keyboard device or a keyboard device

--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -160,11 +160,9 @@ class Keyboard:
         else:
             # Clear any matching slots and move remaining keys down
             j = 0
-            for i in range(_MAX_KEYPRESSES):  # pylint: disable=consider-using-enumerate
+            for i in range(_MAX_KEYPRESSES):
                 pressed = self.report_keys[i]
-                if (  # pylint: disable=consider-using-in
-                    pressed == 0 or pressed == keycode
-                ):
+                if (not pressed) or (pressed == keycode):
                     continue  # Remove this entry
                 self.report_keys[j] = self.report_keys[i]
                 j += 1

--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -147,7 +147,7 @@ class Keyboard:
             # All slots are filled. Shuffle down and reuse last slot
             for i in range(_MAX_KEYPRESSES - 1):
                 self.report_keys[i] = self.report_keys[i + 1]
-                self.report_keys[-1] = keycode
+            self.report_keys[-1] = keycode
 
     def _remove_keycode_from_report(self, keycode: int) -> None:
         """Remove a single keycode from the report."""

--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -135,15 +135,17 @@ class Keyboard:
         else:
             # Don't press twice.
             # (I'd like to use 'not in self.report_keys' here, but that's not implemented.)
+            free_slot = None
             for i in range(_MAX_KEYPRESSES):
+                if free_slot is None and self.report_keys[i] == 0:
+                    free_slot = i
                 if self.report_keys[i] == keycode:
                     # Already pressed.
                     return
             # Put keycode in first empty slot.
-            for i in range(_MAX_KEYPRESSES):
-                if self.report_keys[i] == 0:
-                    self.report_keys[i] = keycode
-                    return
+            if free_slot is not None:
+                self.report_keys[free_slot] = keycode
+                return
             # All slots are filled. Shuffle down and reuse last slot
             for i in range(_MAX_KEYPRESSES - 1):
                 self.report_keys[i] = self.report_keys[i + 1]
@@ -158,9 +160,7 @@ class Keyboard:
         else:
             # Clear any matching slots and move remaining keys down
             j = 0
-            for i in range(  # pylint: disable=consider-using-enumerate
-                len(self.report_keys)
-            ):
+            for i in range(_MAX_KEYPRESSES):  # pylint: disable=consider-using-enumerate
                 pressed = self.report_keys[i]
                 if (  # pylint: disable=consider-using-in
                     pressed == 0 or pressed == keycode
@@ -169,7 +169,7 @@ class Keyboard:
                 self.report_keys[j] = self.report_keys[i]
                 j += 1
             # Check all the slots, just in case there's a duplicate. (There should not be.)
-            while j < len(self.report_keys):
+            while j < _MAX_KEYPRESSES:
                 self.report_keys[j] = 0
                 j += 1
 


### PR DESCRIPTION
When making a keyboard, it's easy for the user to mash plenty of keys at once. While a keyboard firmware _could_ trap the ValueError and continue gracefully, I think it would be nice if instead the oldest keycode is dropped from the report to make room for the newest one.

This does slightly complicate the code but it makes all my keyboard projects more robust.

The pylint disables are in order to avoid new memory allocations, which enumerate() and tuple construction both do.