### PR TITLE
Do not wait for USB for non-USB HID devices

### DIFF
--- a/adafruit_hid/__init__.py
+++ b/adafruit_hid/__init__.py
@@ -28,26 +28,32 @@ except ImportError:
 
 try:
     from typing import Sequence
-    import usb_hid
 except ImportError:
     pass
+
+# usb_hid may not exist on some boards that still provide BLE or other HID devices.
+try:
+    from usb_hid import Device
+except ImportError:
+    Device = None
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_HID.git"
 
 
 def find_device(
-    devices: Sequence[usb_hid.Device],
+    devices: Sequence[object],
     *,
     usage_page: int,
     usage: int,
     timeout: int = None,
-) -> usb_hid.Device:
+) -> object:
     """Search through the provided sequence of devices to find the one with the matching
     usage_page and usage.
 
     :param timeout: Time in seconds to wait for USB to become ready before timing out.
-    Defaults to None to wait indefinitely."""
+    Defaults to None to wait indefinitely.
+    Ignored if device is not a `usb_hid.Device`; it might be BLE, for instance."""
 
     if hasattr(devices, "send_report"):
         devices = [devices]  # type: ignore
@@ -63,20 +69,22 @@ def find_device(
     if device is None:
         raise ValueError("Could not find matching HID device.")
 
-    if supervisor is None:
-        # Blinka doesn't have supervisor (see issue Adafruit_Blinka#711), so wait
-        # one second for USB to become ready
-        time.sleep(1.0)
-    elif timeout is None:
-        # default behavior: wait indefinitely for USB to become ready
-        while not supervisor.runtime.usb_connected:
+    # Wait for USB to be connected only if this is a usb_hid.Device.
+    if Device and isinstance(device, Device):
+        if supervisor is None:
+            # Blinka doesn't have supervisor (see issue Adafruit_Blinka#711), so wait
+            # one second for USB to become ready
             time.sleep(1.0)
-    else:
-        # wait up to timeout seconds for USB to become ready
-        for _ in range(timeout):
-            if supervisor.runtime.usb_connected:
-                return device
-            time.sleep(1.0)
-        raise OSError("Failed to initialize HID device. Is USB connected?")
+        elif timeout is None:
+            # default behavior: wait indefinitely for USB to become ready
+            while not supervisor.runtime.usb_connected:
+                time.sleep(1.0)
+        else:
+            # wait up to timeout seconds for USB to become ready
+            for _ in range(timeout):
+                if supervisor.runtime.usb_connected:
+                    return device
+                time.sleep(1.0)
+            raise OSError("Failed to initialize HID device. Is USB connected?")
 
     return device


### PR DESCRIPTION
Fixes #121.

`find_device()` was waiting for USB to be connected even if the device was not a USB device. Wait only if a USB device was found.

In the long run, maybe the dependency on USB should be decoupled from `find_device()`. In that case, there should be some other way, maybe explicit or implicit, of waiting for the HID transport channel to be ready.

Also there could be an addition to `circuitpython_typing` for duck-typing an HID device.

I tested this on a CLUE.