### PR TITLE
Add constants for mouse back and forward

### DIFF
--- a/adafruit_hid/mouse.py
+++ b/adafruit_hid/mouse.py
@@ -26,6 +26,10 @@ class Mouse:
     """Right mouse button."""
     MIDDLE_BUTTON = 4
     """Middle mouse button."""
+    BACK_BUTTON = 8
+    """Back mouse button."""
+    FORWARD_BUTTON = 16
+    """Forward mouse button."""
 
     def __init__(self, devices: Sequence[usb_hid.Device], timeout: int = None) -> None:
         """Create a Mouse object that will send USB mouse HID reports.


### PR DESCRIPTION
The current Mouse class already supports sending the back and forward buttons (also known as mouse buttons 4 and 5) by passing in the button constants manually. The constants currently included in the library are:

```py
LEFT_BUTTON = 1 # 1 << 0
RIGHT_BUTTON = 2 # 1 << 1
MIDDLE_BUTTON = 4 # 1 << 2
```

This pull request adds the following constants:
```py
BACK_BUTTON = 8 # 1 << 3
FORWARD_BUTTON = 16 # 1 << 4
```

Many mice include these buttons, and applications (such as browsers) support these for forward and backward navigation.

Partially resolves #94 