### PR TITLE
keyboard.py: allow 'import usb_hid' to fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.2.7
     hooks:
       - id: pylint
         name: pylint (library code)

--- a/adafruit_hid/keyboard.py
+++ b/adafruit_hid/keyboard.py
@@ -10,7 +10,6 @@
 """
 
 from micropython import const
-import usb_hid
 
 from .keycode import Keycode
 
@@ -18,7 +17,8 @@ from . import find_device
 
 try:
     from typing import Sequence
-except:  # pylint: disable=bare-except
+    import usb_hid
+except ImportError:
     pass
 
 _MAX_KEYPRESSES = const(6)


### PR DESCRIPTION
keyboard.py unconditionally did `import usb_hid`. This was not necessary and prevented its being used on BLE-only boards. Thanks `@ozzloy` in discord for finding this.