### PR TITLE
Add some more ConsumerControl keycodes

### DIFF
--- a/adafruit_hid/consumer_control_code.py
+++ b/adafruit_hid/consumer_control_code.py
@@ -45,7 +45,7 @@ class ConsumerControlCode:
     """Increase Brightness"""
 
     # some additional codes from a Logitech keyboard, found with Linux evtest
-    CONFIG =0x183
+    CONFIG = 0x183
     """Config"""
     MAIL = 0x18A
     """Mail"""

--- a/adafruit_hid/consumer_control_code.py
+++ b/adafruit_hid/consumer_control_code.py
@@ -44,20 +44,22 @@ class ConsumerControlCode:
     BRIGHTNESS_INCREMENT = 0x6F
     """Increase Brightness"""
 
-    # some additional codes from a Logitech keyboard, found with Linux evtest
-    CONFIG = 0x183
-    """Config"""
-    MAIL = 0x18A
-    """Mail"""
-    CALCULATOR = 0x192
-    """Calculator"""
-    SEARCH = 0x221
-    """Search"""
-    HOMEPAGE = 0x223
-    """Homepage"""
-    BACK = 0x224
-    """Back"""
-    FORWARD = 0x225
-    """Forward"""
-    BOOKMARKS = 0x22A
-    """Bookmarks"""
+    # some additional codes, from a Logitech keyboard, found with Linux evtest
+    # quick use: uncomment the following lines and drop this file in lib/adafruit_hid/
+
+    # CONFIG = 0x183
+    # """Config"""
+    # MAIL = 0x18A
+    # """Mail"""
+    # CALCULATOR = 0x192
+    # """Calculator"""
+    # SEARCH = 0x221
+    # """Search"""
+    # HOMEPAGE = 0x223
+    # """Homepage"""
+    # BACK = 0x224
+    # """Back"""
+    # FORWARD = 0x225
+    # """Forward"""
+    # BOOKMARKS = 0x22A
+    # """Bookmarks"""

--- a/adafruit_hid/consumer_control_code.py
+++ b/adafruit_hid/consumer_control_code.py
@@ -43,3 +43,21 @@ class ConsumerControlCode:
     """Decrease Brightness"""
     BRIGHTNESS_INCREMENT = 0x6F
     """Increase Brightness"""
+
+    # some additional codes from a Logitech keyboard, found with Linux evtest
+    CONFIG =0x183
+    """Config"""
+    MAIL = 0x18A
+    """Mail"""
+    CALCULATOR = 0x192
+    """Calculator"""
+    SEARCH = 0x221
+    """Search"""
+    HOMEPAGE = 0x223
+    """Homepage"""
+    BACK = 0x224
+    """Back"""
+    FORWARD = 0x225
+    """Forward"""
+    BOOKMARKS = 0x22A
+    """Bookmarks"""


### PR DESCRIPTION
Added some more key codes, found with evtest on Linux, from a Logitech keyboard.